### PR TITLE
Use keyword_line_position for SQLFluff FROM clause

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,9 @@ extend-select = [
 line_position = "leading"
 spacing_before = "touch"
 
+[tool.sqlfluff.layout.type.from_clause]
+keyword_line_position = "leading"
+
 [tool.sqlfluff.rules.capitalisation.functions]
 extended_capitalisation_policy = 'upper'
 

--- a/testing/seed.sql
+++ b/testing/seed.sql
@@ -26,7 +26,8 @@ CREATE TABLE accounts (
 INSERT INTO accounts VALUES (
     '8fe2a49b-17b9-47a1-8aaa-c60d661e7f25'
     , (
-        SELECT id FROM plans
+        SELECT id
+        FROM plans
         ORDER BY id LIMIT 1
     )
     , 430000
@@ -40,7 +41,8 @@ INSERT INTO accounts VALUES (
 INSERT INTO accounts VALUES (
     'ab56a1c8-439e-4eaf-931b-37f2d68d1cf5'
     , (
-        SELECT id FROM plans
+        SELECT id
+        FROM plans
         ORDER BY id LIMIT 1
     )
     , -200000
@@ -66,11 +68,13 @@ CREATE TABLE transactions (
 INSERT INTO transactions VALUES (
     'ae3d9f6b-07f1-4c49-9137-5133c8bf0500'
     , (
-        SELECT id FROM plans
+        SELECT id
+        FROM plans
         ORDER BY id LIMIT 1
     )
     , (
-        SELECT id FROM accounts
+        SELECT id
+        FROM accounts
         WHERE name = 'Checking'
         ORDER BY id LIMIT 1
     )
@@ -85,11 +89,13 @@ INSERT INTO transactions VALUES (
 INSERT INTO transactions VALUES (
     '9a97f337-28db-4c2d-990f-d9ec0e9bc765'
     , (
-        SELECT id FROM plans
+        SELECT id
+        FROM plans
         ORDER BY id LIMIT 1
     )
     , (
-        SELECT id FROM accounts
+        SELECT id
+        FROM accounts
         WHERE name = 'Checking'
         ORDER BY id LIMIT 1
     )
@@ -104,11 +110,13 @@ INSERT INTO transactions VALUES (
 INSERT INTO transactions VALUES (
     'c479c335-b54f-48b9-8b74-49a907f1b3f2'
     , (
-        SELECT id FROM plans
+        SELECT id
+        FROM plans
         ORDER BY id LIMIT 1
     )
     , (
-        SELECT id FROM accounts
+        SELECT id
+        FROM accounts
         WHERE name = 'Checking'
         ORDER BY id LIMIT 1
     )
@@ -123,11 +131,13 @@ INSERT INTO transactions VALUES (
 INSERT INTO transactions VALUES (
     '96817e5f-d272-4012-9790-38f8a8e2be90'
     , (
-        SELECT id FROM plans
+        SELECT id
+        FROM plans
         ORDER BY id LIMIT 1
     )
     , (
-        SELECT id FROM accounts
+        SELECT id
+        FROM accounts
         WHERE name = 'Checking'
         ORDER BY id LIMIT 1
     )
@@ -143,11 +153,13 @@ INSERT INTO transactions VALUES (
 INSERT INTO transactions VALUES (
     'eeef0922-b226-4f8a-bf00-66d4d98e348c'
     , (
-        SELECT id FROM plans
+        SELECT id
+        FROM plans
         ORDER BY id LIMIT 1
     )
     , (
-        SELECT id FROM accounts
+        SELECT id
+        FROM accounts
         WHERE name = 'Checking'
         ORDER BY id LIMIT 1
     )
@@ -163,11 +175,13 @@ INSERT INTO transactions VALUES (
 INSERT INTO transactions VALUES (
     '21c45599-4113-4888-9969-66d42553d870'
     , (
-        SELECT id FROM plans
+        SELECT id
+        FROM plans
         ORDER BY id LIMIT 1
     )
     , (
-        SELECT id FROM accounts
+        SELECT id
+        FROM accounts
         WHERE name = 'Credit Card'
         ORDER BY id LIMIT 1
     )
@@ -182,11 +196,13 @@ INSERT INTO transactions VALUES (
 INSERT INTO transactions VALUES (
     '956ff61f-b0e4-4f36-bf7d-f31d008ff7e4'
     , (
-        SELECT id FROM plans
+        SELECT id
+        FROM plans
         ORDER BY id LIMIT 1
     )
     , (
-        SELECT id FROM accounts
+        SELECT id
+        FROM accounts
         WHERE name = 'Credit Card'
         ORDER BY id LIMIT 1
     )
@@ -201,11 +217,13 @@ INSERT INTO transactions VALUES (
 INSERT INTO transactions VALUES (
     'c9ca467d-e89d-4d0d-8356-f37d4f798c5f'
     , (
-        SELECT id FROM plans
+        SELECT id
+        FROM plans
         ORDER BY id LIMIT 1
     )
     , (
-        SELECT id FROM accounts
+        SELECT id
+        FROM accounts
         WHERE name = 'Credit Card'
         ORDER BY id LIMIT 1
     )
@@ -220,11 +238,13 @@ INSERT INTO transactions VALUES (
 INSERT INTO transactions VALUES (
     '258b33fb-a2b2-4833-9274-05697c68ff1d'
     , (
-        SELECT id FROM plans
+        SELECT id
+        FROM plans
         ORDER BY id LIMIT 1
     )
     , (
-        SELECT id FROM accounts
+        SELECT id
+        FROM accounts
         WHERE name = 'Credit Card'
         ORDER BY id LIMIT 1
     )
@@ -240,11 +260,13 @@ INSERT INTO transactions VALUES (
 INSERT INTO transactions VALUES (
     'd9faa297-f59e-4516-bcbf-664b298ff09e'
     , (
-        SELECT id FROM plans
+        SELECT id
+        FROM plans
         ORDER BY id LIMIT 1
     )
     , (
-        SELECT id FROM accounts
+        SELECT id
+        FROM accounts
         WHERE name = 'Credit Card'
         ORDER BY id LIMIT 1
     )


### PR DESCRIPTION
## Summary
- configure the SQLFluff from_clause with keyword_line_position = "leading"
- keep FROM on its own line when fixing SQLite SQL
