### PR TITLE
Include target in no-match output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,9 @@ spacing_before = "touch"
 [tool.sqlfluff.layout.type.from_clause]
 keyword_line_position = "leading"
 
+[tool.sqlfluff.layout.type.when_clause]
+keyword_line_position = "leading"
+
 [tool.sqlfluff.rules.capitalisation.functions]
 extended_capitalisation_policy = 'upper'
 

--- a/reconciler_for_ynab/_main.py
+++ b/reconciler_for_ynab/_main.py
@@ -33,6 +33,8 @@ _PACKAGE = "reconciler-for-ynab"
 
 _NEG_BAL_ACCT_TYPES = frozenset(("checking", "savings", "cash"))
 
+_LOCALE_EN_US = "en_US"
+
 
 @dataclass(frozen=True)
 class Transaction:
@@ -213,7 +215,7 @@ async def _reconcile_account(
             return 0
         else:
             pretty_target = format_currency(
-                target, currency=plan_acct.currency, locale="en_US"
+                target, currency=plan_acct.currency, locale=_LOCALE_EN_US
             )
             print(f"{prefix} No match found for target {pretty_target}")
             return 1
@@ -221,7 +223,7 @@ async def _reconcile_account(
     print(
         f"{prefix} Match found:",
         *(
-            f"{prefix} * {t.pretty(plan_acct.currency, 'en_US')}"
+            f"{prefix} * {t.pretty(plan_acct.currency, _LOCALE_EN_US)}"
             for t in sorted(to_reconcile, key=lambda t: t.amount)
         ),
         sep=os.linesep,

--- a/reconciler_for_ynab/_main.py
+++ b/reconciler_for_ynab/_main.py
@@ -212,7 +212,10 @@ async def _reconcile_account(
             print(f"{prefix} Balance already reconciled to target")
             return 0
         else:
-            print(f"{prefix} No match found")
+            pretty_target = format_currency(
+                target, currency=plan_acct.currency, locale="en_US"
+            )
+            print(f"{prefix} No match found for target {pretty_target}")
             return 1
 
     print(


### PR DESCRIPTION
## Summary
- Print the formatted target amount when no match is found.
- Centralize the locale string in a constant.

## Test plan
- `uv run pytest -q`

Made with [Cursor](https://cursor.com)