### PR TITLE
Use ISO currency code with Babel formatting

### DIFF
--- a/reconciler_for_ynab/_main.py
+++ b/reconciler_for_ynab/_main.py
@@ -253,7 +253,7 @@ def fetch_plan_accts(
                 , accounts.id as account_id
                 , accounts.type as account_type
                 , accounts.cleared_balance
-                , plans.currency_format_currency_symbol
+                , plans.currency_format_iso_code
             FROM accounts
             JOIN plans
                 ON accounts.plan_id = plans.id
@@ -284,7 +284,7 @@ def fetch_plan_accts(
             account_id=pl["account_id"],
             cleared_balance=Decimal(-pl["cleared_balance"]) / 1000,
             account_type=pl["account_type"],
-            currency=pl["currency_format_currency_symbol"],
+            currency=pl["currency_format_iso_code"],
         )
         for pl in plan_accts
     ]

--- a/testing/seed.sql
+++ b/testing/seed.sql
@@ -2,6 +2,7 @@ CREATE TABLE plans (
     id TEXT PRIMARY KEY
     , name TEXT
     , currency_format_currency_symbol TEXT
+    , currency_format_iso_code TEXT
 )
 ;
 
@@ -9,6 +10,7 @@ INSERT INTO plans VALUES (
     'a20542ae-bb3e-4282-8b3e-df3bdea4be10'
     , 'My Plan'
     , '$'
+    , 'USD'
 )
 ;
 

--- a/tests/_main_test.py
+++ b/tests/_main_test.py
@@ -40,14 +40,16 @@ def test_main_version(capsys):
 @patch("reconciler_for_ynab._main.sync")
 @pytest.mark.usefixtures(db.__name__)
 @pytest.mark.parametrize(
-    ("target", "expected"),
+    ("target", "expected", "substr"),
     (
-        pytest.param(500, 0, id="reconciles cleared and uncleared"),
-        pytest.param(430, 0, id="reconciles only cleared"),
-        pytest.param(600, 1, id="no match"),
+        pytest.param(500, 0, None, id="reconciles cleared and uncleared"),
+        pytest.param(430, 0, None, id="reconciles only cleared"),
+        pytest.param(
+            600, 1, "[Checking] No match found for target -$600.00", id="no match"
+        ),
     ),
 )
-def test_main(sync, db, monkeypatch, target, expected):
+def test_main(sync, db, monkeypatch, capsys, target, expected, substr):
     monkeypatch.setenv(_ENV_TOKEN, TOKEN)
 
     ret = main(
@@ -60,8 +62,11 @@ def test_main(sync, db, monkeypatch, target, expected):
             db,
         )
     )
+    out, _ = capsys.readouterr()
     sync.assert_called()
     assert ret == expected
+    if substr is not None:
+        assert substr in out
 
 
 @patch("reconciler_for_ynab._main.sync")


### PR DESCRIPTION
## Summary
- use the plan ISO currency code when calling Babel format_currency for the no-match target output
- extend the test fixture with currency_format_iso_code
- assert the no-match output so the Babel input stays covered

## Why
The existing code passed the currency symbol field such as `$` into Babel's `format_currency(...)`, but Babel expects an ISO currency code such as `USD`.

