### PR TITLE
Use amount_formatted for transaction output

### DIFF
--- a/reconciler_for_ynab/_main.py
+++ b/reconciler_for_ynab/_main.py
@@ -41,11 +41,12 @@ class Transaction:
     plan_id: str
     id: str
     amount: Decimal
+    amount_formatted: str
     payee: str
     cleared: str
 
-    def pretty(self, currency: str, locale: str | None) -> str:
-        return f"{format_currency(self.amount, currency=currency, locale=locale):>10} - {self.payee}"
+    def pretty(self) -> str:
+        return f"{self.amount_formatted:>10} - {self.payee}"
 
 
 @dataclass(frozen=True)
@@ -223,7 +224,7 @@ async def _reconcile_account(
     print(
         f"{prefix} Match found:",
         *(
-            f"{prefix} * {t.pretty(plan_acct.currency, _LOCALE_EN_US)}"
+            f"{prefix} * {t.pretty()}"
             for t in sorted(to_reconcile, key=lambda t: t.amount)
         ),
         sep=os.linesep,
@@ -311,6 +312,7 @@ def fetch_transactions(
                 , plan_id
                 , account_id
                 , amount
+                , amount_formatted
                 , payee_name
                 , cleared
             FROM transactions
@@ -331,6 +333,7 @@ def fetch_transactions(
                 u["plan_id"],
                 u["id"],
                 Decimal(-u["amount"]) / 1000,
+                u["amount_formatted"],
                 u["payee_name"],
                 u["cleared"],
             )

--- a/testing/seed.sql
+++ b/testing/seed.sql
@@ -61,6 +61,7 @@ CREATE TABLE transactions (
     , account_id TEXT
     , "date" TEXT
     , amount INT
+    , amount_formatted TEXT
     , payee_name TEXT
     , cleared TEXT
     , deleted BOOLEAN
@@ -82,6 +83,7 @@ INSERT INTO transactions VALUES (
     )
     , '2025-08-01'
     , 400000
+    , '-$400.00'
     , 'Payee'
     , 'reconciled'
     , 0
@@ -103,6 +105,7 @@ INSERT INTO transactions VALUES (
     )
     , '2025-08-01'
     , 30000
+    , '-$30.00'
     , 'Payee'
     , 'cleared'
     , 0
@@ -124,6 +127,7 @@ INSERT INTO transactions VALUES (
     )
     , '2025-08-01'
     , 60000
+    , '-$60.00'
     , 'Payee'
     , 'uncleared'
     , 0
@@ -145,6 +149,7 @@ INSERT INTO transactions VALUES (
     )
     , '2025-08-01'
     , 20000
+    , '-$20.00'
     , 'Payee'
     , 'uncleared'
     , 0
@@ -167,6 +172,7 @@ INSERT INTO transactions VALUES (
     )
     , '2025-08-01'
     , 10000
+    , '-$10.00'
     , 'Payee'
     , 'uncleared'
     , 0
@@ -189,6 +195,7 @@ INSERT INTO transactions VALUES (
     )
     , '2025-08-01'
     , -400000
+    , '$400.00'
     , 'Payee'
     , 'reconciled'
     , 0
@@ -210,6 +217,7 @@ INSERT INTO transactions VALUES (
     )
     , '2025-08-01'
     , -30000
+    , '$30.00'
     , 'Payee'
     , 'cleared'
     , 0
@@ -231,6 +239,7 @@ INSERT INTO transactions VALUES (
     )
     , '2025-08-01'
     , -60000
+    , '$60.00'
     , 'Payee'
     , 'uncleared'
     , 0
@@ -252,6 +261,7 @@ INSERT INTO transactions VALUES (
     )
     , '2025-08-01'
     , -20000
+    , '$20.00'
     , 'Payee'
     , 'uncleared'
     , 0
@@ -274,6 +284,7 @@ INSERT INTO transactions VALUES (
     )
     , '2025-08-01'
     , -10000
+    , '$10.00'
     , 'Payee'
     , 'uncleared'
     , 0

--- a/tests/_main_test.py
+++ b/tests/_main_test.py
@@ -42,8 +42,15 @@ def test_main_version(capsys):
 @pytest.mark.parametrize(
     ("target", "expected", "substr"),
     (
-        pytest.param(500, 0, None, id="reconciles cleared and uncleared"),
-        pytest.param(430, 0, None, id="reconciles only cleared"),
+        pytest.param(
+            500,
+            0,
+            "[Checking] *    -$60.00 - Payee",
+            id="reconciles cleared and uncleared",
+        ),
+        pytest.param(
+            430, 0, "[Checking] *    -$30.00 - Payee", id="reconciles only cleared"
+        ),
         pytest.param(
             600, 1, "[Checking] No match found for target -$600.00", id="no match"
         ),
@@ -65,8 +72,7 @@ def test_main(sync, db, monkeypatch, capsys, target, expected, substr):
     out, _ = capsys.readouterr()
     sync.assert_called()
     assert ret == expected
-    if substr is not None:
-        assert substr in out
+    assert substr in out
 
 
 @patch("reconciler_for_ynab._main.sync")


### PR DESCRIPTION
## Problem
Transaction output reformats amounts locally instead of using the formatted values already provided by the synced data.

## Solution
Print transaction amounts from the stored `amount_formatted` field and extend the fixture data to cover that path.
