### PR TITLE
Only run CI for project file changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,8 +2,17 @@ name: main
 
 on:
   pull_request:
+    paths: &project_files
+    - .github/workflows/**
+    - '**/*.py'
+    - '**/*.sql'
+    - '**/*.toml'
+    - '**/*requirements*.txt'
+    - '**/setup.cfg'
+    - setup.py
   push:
     branches: [main]
+    paths: *project_files
 
 jobs:
   main:


### PR DESCRIPTION
Problem
CI runs even for metadata-only changes.

Solution
Add path filters to the workflow trigger so it only runs for workflow files and project files that affect the Python package, and keep the filter list DRY with a YAML anchor.