### PR TITLE
Stabilize CI check names

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,7 @@ jobs:
     outputs:
       project_files: ${{ steps.filter.outputs.project_files }}
     steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
     - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
       id: filter
       with:
@@ -23,16 +24,40 @@ jobs:
             - '**/*requirements*.txt'
             - '**/setup.cfg'
             - setup.py
-  main:
+  main-real:
     needs: [changes]
     if: needs.changes.outputs.project_files == 'true'
     uses: asottile/workflows/.github/workflows/tox.yml@adfec6a1ccb5d6b189aa153676d4f0743afa21c1 # v1.11.0
     with:
       env: '["py312", "py313", "py314", "pypy7.3.20"]' # https://github.com/actions/runner-images/blob/4847d9e554d1ad62acec5c5bddfc6175fe1bef4e/images/ubuntu/Ubuntu2204-Readme.md#pypy
-  main-win:
+  main:
+    needs: [changes, main-real]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+    - run: |
+        if [ "${{ needs.changes.outputs.project_files }}" != "true" ]; then
+          exit 0
+        fi
+        if [ "${{ needs.main-real.result }}" != "success" ]; then
+          exit 1
+        fi
+  main-win-real:
     needs: [changes]
     if: needs.changes.outputs.project_files == 'true'
     uses: asottile/workflows/.github/workflows/tox.yml@adfec6a1ccb5d6b189aa153676d4f0743afa21c1 # v1.11.0
     with:
       env: '["py312"]'
       os: windows-latest
+  main-win:
+    needs: [changes, main-win-real]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+    - run: |
+        if [ "${{ needs.changes.outputs.project_files }}" != "true" ]; then
+          exit 0
+        fi
+        if [ "${{ needs.main-win-real.result }}" != "success" ]; then
+          exit 1
+        fi


### PR DESCRIPTION
#### problem
The workflow reports different required-check names depending on whether project files changed. When jobs are skipped before the reusable workflow runs, GitHub reports `main` and `main-win`, but when tests run it reports `main / collector` and `main-win / collector`, which makes branch protection impossible to align cleanly.

#### solution
Split the real reusable-workflow jobs into `main-real` and `main-win-real`, and add always-running wrapper jobs named `main` and `main-win`. Those wrapper jobs no-op succeed when project files did not change and fail if the corresponding real job failed, so branch protection can require one stable pair of check names.